### PR TITLE
Adds an option to toggle the `Received` headers for HTTP connections in Compose.

### DIFF
--- a/config/conf.xml
+++ b/config/conf.xml
@@ -60,7 +60,6 @@
    <configinteger name="htmlsig_img_size" desc="The maximum cumulative size of
    image data that can be contained within the signature. 0 will disable
    this limit (NOT RECOMMENDED).">30000</configinteger>
-
    <configheader>Add Received header</configheader>
    <configboolean name="add_received_header" desc="Adds a header to the mail to
    indicate that Horde received the mail via HTTPS, and exposes the client IP

--- a/config/conf.xml
+++ b/config/conf.xml
@@ -60,6 +60,11 @@
    <configinteger name="htmlsig_img_size" desc="The maximum cumulative size of
    image data that can be contained within the signature. 0 will disable
    this limit (NOT RECOMMENDED).">30000</configinteger>
+
+   <configheader>Add Received header</configheader>
+   <configboolean name="add_received_header" desc="Adds a header to the mail to
+   indicate that Horde received the mail via HTTPS, and exposes the client IP
+   address.">true</configboolean>
   </configsection>
  </configtab>
 

--- a/lib/Compose.php
+++ b/lib/Compose.php
@@ -798,7 +798,7 @@ class IMP_Compose implements ArrayAccess, Countable, IteratorAggregate
         $headers = $this->_prepareHeaders($header, $opts);
 
         /* Add a Received header for the hop from browser to server. */
-        if ($conf['compose']['add_received_header']) {
+        if (!isset($conf['compose']['add_received_header']) || ($conf['compose']['add_received_header'] === true)) {
             $headers->addHeaderOb(
                 Horde_Core_Mime_Headers_Received::createHordeHop()
             );

--- a/lib/Compose.php
+++ b/lib/Compose.php
@@ -745,7 +745,7 @@ class IMP_Compose implements ArrayAccess, Countable, IteratorAggregate
         $body, $header, IMP_Prefs_Identity $identity, array $opts = array()
     )
     {
-        global $injector, $prefs, $registry, $session;
+        global $injector, $prefs, $registry, $session, $conf;
 
         /* Set up defaults. */
         $opts = array_merge(array(
@@ -798,9 +798,11 @@ class IMP_Compose implements ArrayAccess, Countable, IteratorAggregate
         $headers = $this->_prepareHeaders($header, $opts);
 
         /* Add a Received header for the hop from browser to server. */
-        $headers->addHeaderOb(
-            Horde_Core_Mime_Headers_Received::createHordeHop()
-        );
+        if ($conf['compose']['add_received_header']) {
+            $headers->addHeaderOb(
+                Horde_Core_Mime_Headers_Received::createHordeHop()
+            );
+        }
 
         /* Add the 'User-Agent' header. */
         $headers->addHeaderOb(new Horde_Mime_Headers_UserAgent(


### PR DESCRIPTION
Since the `Received` header leaks PII and may also be used detrimentally by spam filters, I've added an option to disable adding the header.

Tests have not been added due to general lack of test coverage and dislike of yak shaving.