### PR TITLE
Update Link.php

### DIFF
--- a/lib/Compose/Link.php
+++ b/lib/Compose/Link.php
@@ -58,7 +58,7 @@ class IMP_Compose_Link
             $mailto = @parse_url($this->args['to']);
             if (is_array($mailto)) {
                 $this->args['to'] = isset($mailto['path'])
-                    ? $mailto['path']
+                    ? urldecode($mailto['path'])
                     : '';
                 if (!empty($mailto['query'])) {
                     parse_str($mailto['query'], $vals);


### PR DESCRIPTION
longer paths are not decoded and not correctly relinked when using navigator.registerProtocolHandler.

See class `IMP_Prefs_Special_Mailto` and then function `public function display(Horde_Core_Prefs_Ui $ui) ....`.

When relinking to imp with e.g. this url `http://dev.horde.localhost/imp/dynamic.php?page=compose&actionID=mailto_link&to=Alma%20Test-ME%20%3Ccm-h1-test@test-mail.de%3E` the `To:` part of the Mail will be full with undecoded url.