### PR TITLE
a fix for searching for Flagged for Followup

### DIFF
--- a/lib/Basic/Search.php
+++ b/lib/Basic/Search.php
@@ -263,10 +263,23 @@ class IMP_Basic_Search extends IMP_Basic_Base
                     break;
 
                 case 'flag':
-                    /* Flag search. */
-                    $formdata = (strpos($id, '0\\') === 0)
-                        ? array('flag' => substr($id, 2), 'set' => false)
-                        : array('flag' => $id, 'set' => true);
+                    /* Flag search. 
+                        TODO: check weither Answer, Draft and so on also need to be set in Uppercase
+                        NOTE: maybe this fix is not solving the root problem
+                    */
+                    $id = $val->v;
+
+                    if (strpos($id, '0\\') !== false){
+                        $flag =  strtoupper(substr($id, 2));
+                        $formdata = array('flag' => $flag, 'set' => false);
+                    }
+                    else if (strpos($id, '%5C') !== false){
+                        $flag = strtoupper(substr($id, 3));
+                        $formdata = array('flag' => $flag, 'set' => true);
+                    }
+                    else {
+                        $formdata = array('flag' => $id, 'set' => true);
+                    }
                     $c_list[] = new IMP_Search_Element_Flag(
                         $formdata['flag'],
                         ($formdata['set'] && !$val->n)

--- a/lib/Basic/Search.php
+++ b/lib/Basic/Search.php
@@ -270,7 +270,7 @@ class IMP_Basic_Search extends IMP_Basic_Base
                     $id = $val->v;
 
                     if (strpos($id, '0\\') !== false){
-                        $flag =  strtoupper(substr($id, 2));
+                        $flag =  substr($id, 2);
                         $formdata = array('flag' => $flag, 'set' => false);
                     }
                     else if (strpos($id, '%5C') !== false){

--- a/lib/Basic/Search.php
+++ b/lib/Basic/Search.php
@@ -264,7 +264,7 @@ class IMP_Basic_Search extends IMP_Basic_Base
 
                 case 'flag':
                     /* Flag search. 
-                        TODO: check weither Answer, Draft and so on also need to be set in Uppercase
+                        TODO: check if the answer-flag, draft-flag and other flags also need to be set to uppercase
                         NOTE: maybe this fix is not solving the root problem
                     */
                     $id = $val->v;


### PR DESCRIPTION
When searching for flagged mails in Imp, there is either an error saying "the IMAP server got an error" or no search results show up.

I found a way to repair this issue, but I am not this solves the problem at the root.