### PR TITLE
Fix for Queue.php TypeError: round(): Argument #1 ($num) must be of type int|float, string given in

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "minimum-stability": "dev",
-    "name": "horde/imp",
+    "name": "bjko/imp",
     "description": "Webmail application",
     "type": "horde-application",
     "homepage": "https://www.horde.org/apps/imp",

--- a/lib/Ajax/Queue.php
+++ b/lib/Ajax/Queue.php
@@ -290,7 +290,7 @@ class IMP_Ajax_Queue
             ($quotadata = $injector->getInstance('IMP_Quota_Ui')->quota($this->_quota[0], $this->_quota[1]))) {
             $ajax->addTask('quota', array(
                 'm' => $quotadata['message'],
-                'p' => round($quotadata['percent']),
+                'p' => round((float)$quotadata['percent']),
                 'l' => $quotadata['percent'] >= 90
                     ? 'alert'
                     : ($quotadata['percent'] >= 75 ? 'warn' : '')

--- a/lib/Ajax/Queue.php
+++ b/lib/Ajax/Queue.php
@@ -290,7 +290,7 @@ class IMP_Ajax_Queue
             ($quotadata = $injector->getInstance('IMP_Quota_Ui')->quota($this->_quota[0], $this->_quota[1]))) {
             $ajax->addTask('quota', array(
                 'm' => $quotadata['message'],
-                'p' => round((float)$quotadata['percent']),
+                'p' => round(floatval($quotadata['percent'])),
                 'l' => $quotadata['percent'] >= 90
                     ? 'alert'
                     : ($quotadata['percent'] >= 75 ? 'warn' : '')


### PR DESCRIPTION
Hi this is a fix for this imp issue:

EMERG: HORDE [imp] TypeError: round(): Argument #1 ($num) must be of type int|float, string given in /horde6/vendor/horde/imp/lib/Ajax/Queue.php
p:293
Stack trace:
#0 /horde6/vendor/horde/imp/lib/Ajax/Queue.php(293): round()
#1 /horde6/vendor/horde/imp/lib/Ajax/Application.php(145): IMP_Ajax_Queue->add()
#2 /horde6/vendor/horde/imp/lib/Ajax/Application.php(134): IMP_Ajax_Application->getTasks()
#3 /horde6/vendor/horde/horde/services/ajax.php(70): IMP_Ajax_Application->send()
#4 {main} [pid 28397 on line 74 of "/horde6/vendor/horde/core/lib/Horde/ErrorHandler.php"]
