### PR TITLE
catch Throwable in IMP_LoginTasks_SystemTask_UpgradeAuth to adjust for php8

### DIFF
--- a/lib/LoginTasks/SystemTask/UpgradeAuth.php
+++ b/lib/LoginTasks/SystemTask/UpgradeAuth.php
@@ -68,7 +68,7 @@ class IMP_LoginTasks_SystemTask_UpgradeAuth extends Horde_Core_LoginTasks_System
                     $cache->deleteMailbox($val);
                 }
             }
-        } catch (Exception $e) {}
+        } catch (Throwable $e) {}
     }
 
 }


### PR DESCRIPTION
in case `Horde_Imap_Client_Cache::_cache` is null at this point `$cache->deleteMailbox($val);` will cause an Error now. In php7 this was an Exception and was ignored by the `catch (Exception $e) {}` part. With php8 we need to catch a `Throwable` instead to preserve the same behaviour.

This still works in php7, as `Exception` implements `Throwable`.